### PR TITLE
Change message.reply to add discord embed to clean up reply

### DIFF
--- a/functions/deviantArt.js
+++ b/functions/deviantArt.js
@@ -35,7 +35,22 @@ module.exports = {
         "*Hmm... not bad. Not bad at all.*"
       ];
 
-      message.reply(chance.pickone(responseList) + " " + meta.image);
+      // Old reply puts entire link into message
+      // message.reply(chance.pickone(responseList) + " " + meta.image);
+
+      /* New reply puts image url into a discord embed object which allows hiding the link
+         in a nicer looking box. Documentation linked below:
+         https://discordjs.guide/popular-topics/embeds.html#using-an-embed-object
+       */
+
+      message.reply(chance.pickone(responseList), 
+        { embed: {
+          title: meta.title,
+          url: meta.url,
+          description: meta.description,
+          image: { url: meta.image }
+        }
+      });
     });
   }
 }

--- a/functions/deviantArt.js
+++ b/functions/deviantArt.js
@@ -35,22 +35,23 @@ module.exports = {
         "*Hmm... not bad. Not bad at all.*"
       ];
 
-      // Old reply puts entire link into message
-      // message.reply(chance.pickone(responseList) + " " + meta.image);
-
       /* New reply puts image url into a discord embed object which allows hiding the link
          in a nicer looking box. Documentation linked below:
          https://discordjs.guide/popular-topics/embeds.html#using-an-embed-object
        */
 
       message.reply(chance.pickone(responseList), 
-        { embed: {
-          title: meta.title,
-          url: meta.url,
-          description: meta.description,
-          image: { url: meta.image }
+        { 
+          embed: {
+            title: meta.title,
+            url: meta.url,
+            description: meta.description,
+            image: {
+              url: meta.image 
+            }
+          }
         }
-      });
+      );
     });
   }
 }


### PR DESCRIPTION
This should work theoretically but should be tested.
<img width="623" alt="Screen Shot 2019-06-26 at 9 24 18 AM" src="https://user-images.githubusercontent.com/323671/60197436-35af3500-97f4-11e9-9b1c-afaaf8df4108.png">

This does not fix the problem where the bot may pull a deviantArt Eclipse version of the website, breaking the way getMETA works to fetch the image and other metadata using regex.